### PR TITLE
Sparse Goldfarb-Idnani dual pivot for the node-time solver (no fallback on degenerate trees)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,14 +4,19 @@
 
 * **Sparse node-time solver (`clsSolver = "sparse"`), now the default.**
   The temporally-constrained least-squares step that estimates internal-node
-  times is now solved with a sparse tree-Laplacian Schur-complement active-set
-  method instead of forming and solving a dense quadratic program. The active set
-  is maintained incrementally (one sparse solve per binding constraint plus a
-  bordered-Cholesky update of the Schur factor), giving `O(n · #active)` per solve
-  rather than `O(n³)`. End-to-end this is roughly 6× faster than the dense solver
-  on a real 1,000-tip relaxed-clock fit and ~15× at 2,000 tips, while returning
-  numerically identical estimates (tMRCA/rate agree with the dense solver to
-  ~1e-8 or better).
+  times is now solved with a sparse tree-Laplacian **Goldfarb–Idnani dual
+  active-set** instead of forming and solving a dense quadratic program. Each
+  step applies `L⁻¹` to one constraint column (an `O(n)` sparse solve) and updates
+  a small dense Schur factor. End-to-end this is roughly 6× faster than the dense
+  solver on a real 1,000-tip relaxed-clock fit and ~15× at 2,000 tips, while
+  returning numerically identical estimates (tMRCA/rate agree with the dense
+  solver to ~1e-8 or better).
+
+  Because it is a *dual* method, it also converges on **degenerate** constraint
+  sets — many linearly-dependent binding constraints, common on large,
+  non-clock-like trees — by exchanging constraints, where the earlier primal
+  active-set had to fall back to the dense `quadprog` solver (e.g. ~14× faster
+  than that fallback at 4,000 tips).
 
   The dense solver is available as `clsSolver = "quadprog"`, and `"mgcv"` is
   unchanged. The sparse path requires the **Matrix** package (a recommended

--- a/R/treedater0.R
+++ b/R/treedater0.R
@@ -281,23 +281,24 @@ sampleYearsFromLabels <- function(tips, dateFormat='%Y-%m-%d'
 	unname( quadprog::solve.QP( Dmat, cvec, Amat = -t(td$Ain), bvec = -td$bin )$solution )
 }
 
-# Sparse Schur-complement ACTIVE-SET for the ti5 node-time QP (clsSolver="sparse", the
+# Sparse GOLDFARB-IDNANI dual active-set for the ti5 node-time QP (clsSolver="sparse", the
 # default).
 #
 # The weighted normal-equations matrix A'WA is a weighted TREE LAPLACIAN (each edge
 # contributes <=2 non-zeros per row), and the node-ordering constraints Ain x <= bin
-# (parent time <= child/tip time) are single edge rows. So instead of the dense O(n^3)
-# QP (which forms A'A and solves a dense QP every coordinate-descent iteration) we:
+# (parent time <= child/tip time) are single edge rows. So instead of forming A'A and
+# solving a dense O(n^3) QP every coordinate-descent iteration we:
 #   * factor the sparse tree Laplacian L = A'WA ONCE with a sparse Cholesky (CHOLMOD via
 #     the Matrix package finds the tree's perfect elimination ordering -> O(n), no fill),
-#   * apply L^-1 to the rhs, and maintain Z = L^-1 E' one column at a time as constraints
-#     enter the active set (each new column is one O(n) sparse solve),
-#   * maintain a Cholesky factor of the small dense |active| x |active| Schur system by a
-#     bordered rank-1 update (refactored only on the rare constraint release),
-#   * add the most-violated constraint / release a negative multiplier each step
-#     (a standard primal active-set).
-# Cost is O(n * #active) instead of O(n^3). Returns NULL (caller falls back to the dense
-# quadprog solver) if Matrix is unavailable, the factor is singular, or it fails to converge.
+#   * run a DUAL active-set from the unconstrained solution x0 = L^-1 A'WB, bringing in the
+#     most-violated constraint by raising its multiplier; each step applies L^-1 to one
+#     constraint column (an O(n) sparse solve) and updates a small dense Schur factor,
+#   * on a linearly-dependent (degenerate) active set it takes a partial dual step and
+#     EXCHANGES a constraint (drops the blocking one) instead of failing -- so, unlike a
+#     plain primal active-set, it always converges to the true KKT point (feasible optimum)
+#     even when many constraints bind, rather than falling back to the dense solver.
+# Returns NULL (caller falls back to the dense quadprog solver) only if Matrix is
+# unavailable, the factor is singular, or it fails to converge within the iteration cap.
 .optim.Ti5.sparse.activeset <- function(omegas, td){
 	if (!requireNamespace('Matrix', quietly = TRUE)) return(NULL)
 	tre <- td$tre; n <- td$n; p <- n - 1L
@@ -340,57 +341,58 @@ sampleYearsFromLabels <- function(tips, dateFormat='%Y-%m-%d'
 	evec <- function(k){ e <- numeric(p); e[parcol[k]] <- 1; if (!is.na(childcol[k])) e[childcol[k]] <- -1; e }
 
 	x0 <- as.numeric(solveL(cvec))
-	active <- integer(0); tol <- 1e-9
-	# INCREMENTAL active-set: maintain Z = L^-1 E' one column at a time and a Cholesky
-	# factor R of the Schur matrix S = E Z (bordered rank-1 update on add, refactor on the
-	# rare release), so each step costs ONE sparse solve + O(#active^2) instead of
-	# re-solving all #active columns and an O(#active^3) dense system from scratch every step.
-	Z <- matrix(0, p, 0)      # columns L^-1 e_k, one per active constraint
-	R <- matrix(0, 0, 0)      # upper Cholesky of S:  crossprod(R) == S
-	for (it in seq_len(ne + 5L)){
-		m <- length(active)
-		if (m == 0L){
-			x <- x0; mult <- numeric(0)
-		} else {
-			rs <- vapply(active, function(k) row_val(k, x0) - binv[k], numeric(1))
-			mu <- backsolve(R, backsolve(R, rs, transpose = TRUE))   # S mu = rs  via S = R'R
-			x  <- x0 - as.numeric(Z %*% mu); mult <- mu
-		}
+	# Dual active-set state: primal x, active constraint indices, multipliers lam >= 0,
+	# the columns Za = L^-1 a_j for active j, and a Cholesky factor Rm of the Schur matrix
+	# M = A_active L^-1 A_active' (crossprod(Rm) == M).
+	x <- x0; active <- integer(0); lam <- numeric(0)
+	Za <- matrix(0, p, 0); M <- matrix(0, 0, 0); Rm <- matrix(0, 0, 0)
+	tol <- 1e-9; eps <- 1e-11; maxit <- 6L * ne + 50L; nit <- 0L
+	for (outer in seq_len(maxit)){
 		# most-violated inactive constraint  (Ain x - bin > 0)
 		lhs <- x[parcol]; lhs[ni] <- lhs[ni] - x[childcol[ni]]
-		viol <- lhs - binv; viol[active] <- -Inf
+		viol <- lhs - binv; if (length(active)) viol[active] <- -Inf
 		kb <- which.max(viol)
-		if (length(kb) && viol[kb] > tol){
-			# ADD constraint kb: one sparse solve for its column + bordered Cholesky update
-			z <- as.numeric(solveL(evec(kb))); d <- row_val(kb, z)
-			if (m == 0L){
-				if (d <= 0) return(NULL)
-				R <- matrix(sqrt(d), 1, 1)
-			} else {
-				s <- vapply(active, function(k) row_val(k, z), numeric(1))
-				r <- backsolve(R, s, transpose = TRUE); rho2 <- d - sum(r * r)
-				if (rho2 <= 0) return(NULL)          # constraint (nearly) dependent -> fall back
-				R <- rbind(cbind(R, r), c(rep(0, m), sqrt(rho2)))
-			}
-			Z <- cbind(Z, z); active <- c(active, kb); next
+		if (!length(kb) || viol[kb] <= tol){         # no violation + lam >= 0  ->  KKT optimal
+			ztol <- sqrt(.Machine$double.eps); x[abs(x) < ztol] <- 0
+			return(x)
 		}
-		# release the most-negative multiplier
-		if (m > 0L){
-			mn <- which.min(mult)
-			if (mult[mn] < -tol){
-				active <- active[-mn]; Z <- Z[, -mn, drop = FALSE]
-				if (length(active) == 0L){ R <- matrix(0, 0, 0) }
+		wa  <- as.numeric(solveL(evec(kb)))          # L^-1 a_kb  (one O(n) sparse solve)
+		dpp <- row_val(kb, wa)                        # a_kb' L^-1 a_kb  (> 0)
+		lam_p <- 0
+		repeat {                                      # raise lam_kb until kb is tight or a drop
+			nit <- nit + 1L; if (nit > maxit) return(NULL)
+			m <- length(active)
+			if (m == 0L){ s <- numeric(0); r <- numeric(0); zdir <- wa; rho2 <- dpp }
+			else {
+				s    <- vapply(active, function(k) row_val(k, wa), numeric(1))  # M's kb-column
+				r    <- backsolve(Rm, backsolve(Rm, s, transpose = TRUE))       # M^-1 s : dual dir
+				zdir <- wa - as.numeric(Za %*% r)                              # primal dir
+				rho2 <- dpp - sum(s * r)                                       # a_kb' zdir  (Schur)
+			}
+			viol_p <- row_val(kb, x) - binv[kb]
+			t2 <- if (rho2 > eps) viol_p / rho2 else Inf     # primal (full) step: make kb tight
+			t1 <- Inf; kdrop <- 0L                           # dual (partial) step: a lam hits 0
+			if (m > 0L){
+				pos <- which(r > eps)
+				if (length(pos)){ ra <- lam[pos] / r[pos]; wi <- which.min(ra); t1 <- ra[wi]; kdrop <- pos[wi] }
+			}
+			tt <- min(t1, t2); if (!is.finite(tt)) return(NULL)   # primal infeasible (should not happen)
+			x <- x - tt * zdir; if (m > 0L) lam <- lam - tt * r; lam_p <- lam_p + tt
+			if (t2 <= t1){                                # FULL step: kb becomes active
+				if (m == 0L){ M <- matrix(dpp, 1, 1); Rm <- matrix(sqrt(dpp), 1, 1) }
 				else {
-					S <- matrix(0, length(active), length(active))
-					for (a in seq_along(active)) S[a, ] <- vapply(active, function(k) row_val(k, Z[, a]), numeric(1))
-					R <- tryCatch(chol(S), error = function(e) NULL)
-					if (is.null(R)) return(NULL)
+					rr <- backsolve(Rm, s, transpose = TRUE)
+					M  <- rbind(cbind(M, s), c(s, dpp))
+					Rm <- rbind(cbind(Rm, rr), c(rep(0, m), sqrt(max(rho2, eps))))
 				}
-				next
+				Za <- cbind(Za, wa); active <- c(active, kb); lam <- c(lam, lam_p); break
+			} else {                                      # PARTIAL step: EXCHANGE - drop constraint kdrop
+				active <- active[-kdrop]; lam <- lam[-kdrop]; Za <- Za[, -kdrop, drop = FALSE]
+				M  <- M[-kdrop, -kdrop, drop = FALSE]
+				Rm <- if (nrow(M) == 0L) matrix(0, 0, 0) else tryCatch(chol(M), error = function(e) NULL)
+				if (is.null(Rm)) return(NULL)
 			}
 		}
-		ztol <- sqrt(.Machine$double.eps); x[abs(x) < ztol] <- 0
-		return(x)
 	}
 	NULL
 }

--- a/notes/sparse-active-set.md
+++ b/notes/sparse-active-set.md
@@ -3,29 +3,45 @@
 ## Summary
 
 `treedater`'s inner node‑time optimisation was `O(n³)` per iteration, which
-dominated run time on large trees. This change adds a **sparse Schur‑complement
-active‑set** solver that is `O(n · #active‑constraints)` per solve — several
+dominated run time on large trees. This change adds a **sparse Goldfarb–Idnani
+dual active‑set** solver that is `O(n · #active‑constraints)` per solve — several
 times faster on real relaxed‑clock fits — while returning numerically identical
 estimates. It is exposed through a new value of the existing `clsSolver`
 argument, `clsSolver = "sparse"`, which is now the **default**. A dense reference
 solver is available as `clsSolver = "quadprog"`.
 
-**End‑to‑end speed‑up on real data** (UK subtype‑C HIV tree, additive relaxed
-clock, `omega0 = 0.0015`, single start, `ncpu = 1`; `sparse` vs. the dense
-`quadprog` solver, identical estimates):
+**Realistic end‑to‑end wall‑clock on real data.** All figures are full `dater()`
+fits at `ncpu = 1`, sparse (GI) vs. the dense solver, with numerically identical
+estimates. Note `ncpu` parallelises only the root search / start conditions /
+`parboot`, *not* the node‑time solver, so the *speed‑up ratio* is
+`ncpu`‑independent (with `ncpu > 1` both absolute times drop for unrooted trees).
 
-| n (tips) | `quadprog` (dense) | `sparse` (new) | speed‑up | Δ tMRCA |
-|---------:|-------------------:|---------------:|---------:|--------:|
-|   1 000  |      11.3 s        |     1.9 s      |    6×    | 1.2e‑8  |
-|   2 000  |      84.9 s        |     5.8 s      |   15×    | 2.2e‑7  |
+UK subtype‑C HIV (rate‑heterogeneous, additive clock):
 
-The single‑solve speed‑up grows with `n` and, on *idealised* perfectly
-clock‑like trees, reaches 100×+ — but that best case has **zero** binding
-ordering constraints. Real rate variation makes `O(n)` constraints bind, so the
-realistic end‑to‑end gain is the ~6–15× above. Beyond ~3 500 tips a single solve
-on real data can hit a degenerate (rank‑deficient) active set; the solver then
-falls back to the dense `quadprog` path (detecting the degeneracy in seconds
-rather than churning). See "Scaling and limits" below.
+| n (tips)       | dense             | sparse (GI) | speed‑up |
+|---------------:|------------------:|------------:|---------:|
+|   1 000        |   11 s            |    1.9 s    |    6×    |
+|   2 000        |   85 s            |    5.8 s    |   15×    |
+|  11 695 (full) |  ~10 h (limSolve, historical) | 22 min | ~28× |
+
+EBOV Makona (very clock‑like — one ~1‑year outbreak → the *least*‑favourable case,
+BioNJ tree so with a 5‑way root search):
+
+| n (tips)         | dense (limSolve) | sparse (GI) | speed‑up |
+|-----------------:|-----------------:|------------:|---------:|
+| 1 030 strict     |   584 s          |   184 s     |   3.2×   |
+| 1 030 additive   |   286 s          |    57 s     |   5.0×   |
+| 1 609 additive   |  (~20 min, est.) |   2.7 min   |   ~7×    |
+
+Two rules of thumb: the gain **grows with tree size** (the dense `O(n³)` cost bites
+harder) and **with rate heterogeneity** (more binding ordering constraints → the
+dense QP churns while the sparse solver stays cheap). So expect ~3× on small,
+clock‑like data and ~15–30× on large or rate‑varying trees. It is a **constant
+factor, not an asymptotic win** — on real data ~30% of ordering constraints bind,
+so the solver stays `O(n³)`‑order (see "Scaling and limits"). The idealised "100×+"
+only appears on perfectly clock‑like trees where *no* constraints bind. On the
+degenerate large‑tree solves the dual pivot **converges directly** (it does not
+fall back to the dense solver — see "Scaling and limits").
 
 ## The bottleneck
 

--- a/notes/sparse-active-set.md
+++ b/notes/sparse-active-set.md
@@ -63,37 +63,40 @@ Two observations make the problem sparse:
 
 ## The algorithm (`.optim.Ti5.sparse.activeset`)
 
-We solve the constrained QP with a primal **active‑set** method whose linear
-algebra is driven by a **single sparse factorisation** of the tree Laplacian
-`L = AᵀWA`, with the working‑set linear algebra maintained **incrementally**:
+We solve the constrained QP with a **Goldfarb–Idnani dual active‑set** method
+whose linear algebra is driven by a **single sparse factorisation** of the tree
+Laplacian `L = AᵀWA`:
 
 1. **Factor once.** Build `L` as a sparse matrix and factor it with a sparse
    Cholesky (`Matrix::Cholesky`, i.e. CHOLMOD). On a tree, the elimination tree
    has no fill‑in, so the factor is `O(n)` to compute and to apply. (This is the
    linear‑algebra equivalent of a post‑order Gaussian elimination that walks the
    tree from tips to root.)
-2. **Unconstrained solve.** `x0 = L⁻¹ c`, where `c = AᵀWB` is the right‑hand
-   side (`O(n)`).
-3. **Active‑set iterations.** Maintain a working set of binding constraints
-   `E x = f`, the matrix `Z = L⁻¹ Eᵀ`, and a Cholesky factor of the Schur matrix
-   `S = E Z` — all updated **one column at a time**:
-   - when a constraint enters, solve for its single new column of `Z` with one
-     `O(n)` sparse solve and extend the Schur factor by a **bordered rank‑1
-     update**; on the (rare) release, drop the column and refactor;
-   - solve the small dense Schur system `S μ = E x0 − f` for the multipliers `μ`
-     using the maintained factor;
-   - update `x = x0 − Z μ`;
-   - **add** the most‑violated inactive constraint, or **release** the
-     constraint with the most‑negative multiplier, and repeat.
-4. **Terminate** when no constraint is violated and all multipliers are
-   non‑negative (KKT satisfied).
+2. **Start dual‑feasible.** Begin at the unconstrained minimiser `x0 = L⁻¹ c`
+   (`c = AᵀWB`) with an empty active set — trivially dual‑feasible (all
+   multipliers zero).
+3. **Dual iterations.** Repeatedly pick the most‑violated constraint `p` and
+   raise its multiplier, keeping the active constraints tight and all multipliers
+   `≥ 0`. For the incoming row `aₚ` compute `wₐ = L⁻¹ aₚ` (one `O(n)` sparse
+   solve) and, against the active set, the primal step direction `z` and the dual
+   step direction `r = M⁻¹ (A_active wₐ)` — using a maintained Cholesky of the
+   Schur matrix `M = A_active L⁻¹ A_activeᵀ`. Then take the shorter of
+   - the **primal (full) step** `t₂ = viol / (aₚᵀz)` that makes `p` tight, after
+     which `p` enters the active set (append its column `wₐ`, extend the Schur
+     factor by a bordered update); or
+   - the **dual (partial) step** `t₁ = minₖ λₖ/rₖ` at which an active multiplier
+     reaches zero, after which that constraint is **dropped** — a constraint
+     *exchange* — and the same `p` is retried against the smaller active set.
+4. **Terminate** when no constraint is violated (multipliers are `≥ 0` by
+   construction) — the KKT conditions hold, so `x` is the feasible optimum.
 
-Because each add/drop touches one column, a step costs one sparse solve plus
-`O(#active²)` dense work, rather than re‑solving all `#active` columns and an
-`O(#active³)` dense system from scratch every step. The tree factor is reused
-across all active‑set iterations. For tree node‑ordering constraints the active
-set is, in practice, **monotonic** — constraints enter and stay — so the release
-path is essentially never exercised.
+The exchange in step 3 is what makes this robust. When the incoming constraint is
+linearly dependent on the active set (`aₚᵀz ≤ 0` — a degenerate, rank‑deficient
+active set) the primal step is infinite, so the method instead drops a blocking
+constraint and proceeds, always reaching the true optimum. A plain *primal*
+active‑set has no such move and must give up (fall back to the dense solver) on
+exactly those instances. Each step costs one `O(n)` sparse solve plus `O(#active²)`
+dense work, and the tree factor is reused throughout.
 
 ## Scaling and limits
 
@@ -110,25 +113,23 @@ data (empirically the per‑solve time scales ~`n^2.3`). So on real data this is
   it no faster (or slightly slower) than the dense solver, but the node‑time
   solve is not a repeated hot path there, so it does not matter. The win shows up
   from ~500–1 000 tips upward.
-- **Degeneracy → fallback.** When many constraints bind they can become linearly
-  dependent; the bordered Cholesky detects this the moment such a constraint would
-  enter (`ρ² ≤ 0`), the solver returns `NULL`, and the caller falls back to the
-  dense `quadprog` solve. On the real subtype‑C tree this starts to appear around
-  ~4 000 tips, but it is **sporadic and instance‑dependent**, not a hard threshold:
-  a 4 500‑tip subsample converges (in ~33 s) while the 4 000‑ and 5 000‑tip
-  subsamples fall back. Two distinct costs: the incremental factor makes the
-  *failed sparse attempt* cheap (it bails in seconds rather than churning for
-  minutes), but the dense `quadprog` solve it then falls back to is still a full
-  `O(n³)` solve and dominates that node‑time step. Failing fast saves the wasted
-  attempt; it does not make the fallback solve cheap.
+- **Degeneracy — handled, no longer a fallback.** When many constraints bind they
+  can become linearly dependent (a rank‑deficient active set, a genuine LICQ
+  failure). The dual method handles this directly through the constraint
+  *exchange* in step 3: it drops a blocking constraint and continues to the true
+  feasible optimum. On the real subtype‑C tree the degeneracy appears sporadically
+  from ~4 000 tips upward (e.g. the 4 000‑ and 5 000‑tip subsamples), and the dual
+  solver converges on them at roughly the non‑degenerate sparse speed — **~14×
+  faster than the dense fallback it replaces** (26 s vs ~370 s at 4 000 tips),
+  staying feasible and matching `quadprog` to ~1e‑12.
 
-  Falling back is deliberate. A degenerate active set is a genuine LICQ failure
-  that a robust *dual* QP method (`quadprog`'s Goldfarb‑Idnani) handles correctly.
-  Simply regularising the Schur to push through the degeneracy was tried and
-  **produces infeasible node times** (parent younger than child, error growing
-  with `n`) — so the sparse solver hands these instances to `quadprog` rather than
-  return a wrong answer. Making the sparse path itself robust to degeneracy would
-  require a proper sparse dual pivot (a larger project).
+  This is why the method is a *dual* active‑set. The previous *primal* version
+  detected the degeneracy (`ρ² ≤ 0`) but had to fall back to a full dense
+  `quadprog` solve; and a cheaper attempt — regularising the Schur to push
+  through — **produced infeasible node times** (parent younger than child, error
+  growing with `n`). `quadprog` remains only as the ultimate backstop for the
+  unlikely cases where the sparse factor is singular or the **Matrix** package is
+  unavailable.
 
 ## The API option
 

--- a/tests/testthat/test-sparse-solver.R
+++ b/tests/testthat/test-sparse-solver.R
@@ -297,3 +297,26 @@ test_that(".optim.Ti0.sparse (unconstrained path) matches the dense lm solution"
     expect_equal(xs, xl, tolerance = 1e-6, info = sprintf("seed=%d svbr=%s", seed, svbr))
   }
 })
+
+# =============================================================================
+test_that("sparse solver converges on degenerate constraint sets (GI constraint exchange)", {
+  skip_if_not_installed("Matrix")
+  skip_if_not_installed("quadprog")
+  # Non-clock-like data (random tree + random sample times) makes many node-ordering
+  # constraints bind and go linearly dependent -- a degenerate active set. The dual
+  # (Goldfarb-Idnani) solver must converge to the true FEASIBLE optimum here via constraint
+  # exchange, matching quadprog. (A plain primal active-set bails / returns NULL on this.)
+  for (n in c(200L, 400L)) for (seed in 1:2) {
+    set.seed(seed * 13 + n)
+    tr  <- ape::rtree(n)
+    sts <- stats::setNames(runif(n, 2000, 2020), tr$tip.label)
+    td  <- treedater:::.make.tree.data(tr, sts, s = 1000, cc = 10)
+    om  <- rep(1, nrow(td$tre$edge))
+    xg <- treedater:::.optim.Ti5.sparse.activeset(om, td)
+    xq <- treedater:::.optim.Ti5.constrained.quadprog(om, td)
+    label <- sprintf("n=%d seed=%d", n, seed)
+    expect_false(is.null(xg), info = paste("sparse solver bailed on degenerate", label))
+    expect_lte(max(as.numeric(td$Ain %*% xg) - td$bin), 1e-6)          # feasible
+    expect_equal(xg, xq, tolerance = 1e-6, info = label)               # true optimum
+  }
+})


### PR DESCRIPTION
## Summary

Replaces the primal sparse active-set node-time solver (`.optim.Ti5.sparse.activeset`) with a **Goldfarb–Idnani dual active-set** over the same sparse tree-Laplacian Cholesky.

The primal solver **bailed** (returned `NULL`, forcing the dense `quadprog` fallback) whenever the active set became linearly dependent — a rank-deficient / **degenerate** constraint set, which is common on large, rate-heterogeneous trees. The dual pivot handles this correctly: it takes a **partial (dual) step that exchanges a constraint** (drops a blocking one) instead of giving up, so it always converges to the true feasible optimum.

## Results

- **Numerically identical** where the primal solver converged (~1e-12), and it **converges + stays feasible** on the degenerate instances where the primal version bailed (validated against `quadprog`). A naive "regularise the Schur" shortcut was tried first and produced *infeasible* node times — hence the proper dual pivot.
- On real degenerate solves it is **~14× faster than the dense fallback** it replaces (26 s vs ~370 s at 4000 tips). The full 11,695-tip UK subtype-C HIV additive fit runs in **~22 min with zero fallbacks** (≈28× vs the ~10 h historical limSolve run).
- Independent EBOV Makona dataset (strict + additive, 200–1609 tips): tMRCA/rate **identical** to the pre-PR limSolve build; GI ~3–7× faster, zero fallbacks.
- `quadprog` remains only as the ultimate backstop (singular factor / `Matrix` unavailable).

## Validation

- Full `testthat` suite: **90 assertions**, including a new degeneracy regression test (an instance that made the primal solver bail).
- Real-data benchmarks (HIV subtype-C, EBOV Makona) documented in `notes/sparse-active-set.md`.

## Notes / caveats

- Still `O(n³)`-order on real data (~30% of ordering constraints bind), so this is a large **constant-factor** win + robustness, **not** an asymptotic change. The idealised "100×+" only holds when no constraints bind.
- A C++ (RcppEigen) GI loop is a natural follow-up — the loop is currently pure R and is `#active`-bound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
